### PR TITLE
Change compile to implementation in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,5 @@ repositories {
 dependencies {
     implementation 'org.jetbrains:annotations:20.1.0'
 
-    compile('io.github.classgraph:classgraph:4.8.105')
+    implementation 'io.github.classgraph:classgraph:4.8.105'
 }
-


### PR DESCRIPTION
Reason: [compile is deprecated since 3.4](https://docs.gradle.org/current/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations)