### PR TITLE
Fix creating a file instead of a folder when plugins folder doesn't exist

### DIFF
--- a/src/main/java/de/spark61/pluginsystem/PluginSystem.java
+++ b/src/main/java/de/spark61/pluginsystem/PluginSystem.java
@@ -88,7 +88,7 @@ public class PluginSystem {
     public void loadPlugins() throws IOException, IllegalClassFormatException {
         final File folder = new File(PluginSystem.PLUGIN_FOLDER);
         if (!folder.exists()) {
-            final boolean created = folder.createNewFile();
+            final boolean created = folder.mkdirs();
         }
 
         final File[] files = folder.listFiles();


### PR DESCRIPTION
When the plugin folders doesn't exist, it should create it.
However, instead of `File#mkdirs` you used `File#createNewFile`, which will create a file with that name instead of a directory.